### PR TITLE
Update README to include non-root brunch install

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Clone this repo!
 
 * Install (if you don't have them):
     * [Node.js](http://nodejs.org): `brew install node` on OS X
-    * [Brunch](http://brunch.io): `npm install -g brunch`
+    * [Brunch](http://brunch.io): `npm install -g brunch` as root, or `npm install brunch` for the current user
     * Brunch plugins and app dependencies: `npm install`
 * Run:
     * `npm start` — watches the project with continuous rebuild. This will also launch HTTP server with [pushState](https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Manipulating_the_browser_history).


### PR DESCRIPTION
List an option for npm to run as non-root user.

On Linux, you usually don't `su` to an admin user for installations. in that case the global flag `-g` of the brunch install may have permission problems. An easy fix in that case is to just leave out the global flag as you will likely only run that server from the user that cloned the repository anyway.

With the flag I got errors, without the flag, everything worked.